### PR TITLE
Prevent back-navigation after logout

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -3,24 +3,27 @@
 // =====================================================================
 
 // ── Toast ─────────────────────────────────────────────────────────────────
-function showToast(message, type, duration) {
-    type     = type     || 'info';
-    duration = duration || 5000;
-    var container = document.getElementById('toast-container');
-    if (!container) return;
-    var toast = document.createElement('div');
-    toast.className   = 'toast ' + type;
-    toast.textContent = message;
-    container.appendChild(toast);
-    requestAnimationFrame(function () {
-        requestAnimationFrame(function () { toast.classList.add('show'); });
-    });
-    setTimeout(function () {
-        toast.classList.remove('show');
+// We check if showToast is already defined (inline in logout.ejs) to avoid duplicates
+if (typeof window.showToast !== 'function') {
+    window.showToast = function(message, type, duration) {
+        type     = type     || 'info';
+        duration = duration || 5000;
+        var container = document.getElementById('toast-container');
+        if (!container) return;
+        var toast = document.createElement('div');
+        toast.className   = 'toast ' + type;
+        toast.textContent = message;
+        container.appendChild(toast);
+        requestAnimationFrame(function () {
+            requestAnimationFrame(function () { toast.classList.add('show'); });
+        });
         setTimeout(function () {
-            if (container.contains(toast)) container.removeChild(toast);
-        }, 350);
-    }, duration);
+            toast.classList.remove('show');
+            setTimeout(function () {
+                if (container.contains(toast)) container.removeChild(toast);
+            }, 350);
+        }, duration);
+    };
 }
 
 // ── Decode JWT exp claim client-side ──────────────────────────────────────
@@ -91,13 +94,13 @@ function handleSessionExpired() {
     clearInterval(countdownInterval);
     localStorage.removeItem('token');
     sessionStorage.removeItem('logoutPageActive');
-    showToast(
+    window.showToast(
         'Session expired — logged out automatically. Please log in again.',
         'warning',
         4000
     );
     setTimeout(function () {
-        window.location.replace('http://localhost:3000');
+        window.location.replace('http://localhost:3000/?loggedOut=true');
     }, 4000);
 }
 
@@ -107,7 +110,7 @@ function doLogout() {
     clearTimeout(sessionTimeout);
     localStorage.removeItem('token');
     sessionStorage.removeItem('logoutPageActive');
-    showToast(
+    window.showToast(
         'Logged out successfully — please log in again to access the app.',
         'success',
         4000
@@ -115,7 +118,7 @@ function doLogout() {
     // location.replace() removes the logout page from browser history so
     // the back button from localhost:3000 cannot return here.
     setTimeout(function () {
-        window.location.replace('http://localhost:3000');
+        window.location.replace('http://localhost:3000/?loggedOut=true');
     }, 4000);
 }
 
@@ -123,42 +126,18 @@ function doLogout() {
 document.addEventListener('DOMContentLoaded', function () {
 
     // ── sessionStorage back-navigation guard ──────────────────────────────
-    // sessionStorage is NOT restored when the browser serves a cached page
-    // via the back button. So the flag is only present on a live session.
-    //
-    // Genuine first load:   flag absent → read URL token, set flag, continue
-    // Back-nav after logout: flag absent AND token gone → redirect instantly
-    var alreadyActive = sessionStorage.getItem('logoutPageActive');
-    var params        = new URLSearchParams(window.location.search);
-    var urlToken      = params.get('token');
+    // The history trap and token cleanup are handled aggressively in the
+    // inline script within logout.ejs to ensure they execute as early as possible.
+    // This DOMContentLoaded block handles secondary initialization.
 
-    if (!alreadyActive) {
-        var storedToken = localStorage.getItem('token');
-
-        if (!storedToken && !urlToken) {
-            // No token anywhere — redirect immediately
-            window.location.replace('http://localhost:3000');
-            return;
-        }
-
-        if (!storedToken && urlToken) {
-            // First genuine load — store the URL token and set the flag
-            localStorage.setItem('token', urlToken);
-            sessionStorage.setItem('logoutPageActive', '1');
-        } else {
-            // Token already in localStorage — just set the flag
-            sessionStorage.setItem('logoutPageActive', '1');
-        }
-    }
-    // Once alreadyActive is set we never re-read the URL token.
-    // Back-navigation cannot restore the token through the URL.
-
-    // Final check
     var token = localStorage.getItem('token');
     if (!token) {
-        window.location.replace('http://localhost:3000');
+        // This is a fallback in case the inline script's redirect hasn't fired yet
+        window.location.replace('http://localhost:3000/?loggedOut=true');
         return;
     }
+
+    sessionStorage.setItem('logoutPageActive', '1');
 
     // Start the session expiry watcher against the current (1-hour) token
     checkSession();
@@ -204,7 +183,7 @@ document.addEventListener('DOMContentLoaded', function () {
         })
         .then(function (data) {
             if (!data.success) {
-                showToast(data.msg || 'Could not begin logout. Please try again.', 'error');
+                window.showToast(data.msg || 'Could not begin logout. Please try again.', 'error');
                 proceedBtn.disabled    = false;
                 proceedBtn.textContent = 'Proceed to logout';
                 return;
@@ -226,7 +205,7 @@ document.addEventListener('DOMContentLoaded', function () {
         })
         .catch(function (err) {
             var msg = (err && err.msg) ? err.msg : 'Network error. Please try again.';
-            showToast(msg, 'error');
+            window.showToast(msg, 'error');
             proceedBtn.disabled    = false;
             proceedBtn.textContent = 'Proceed to logout';
         });

--- a/routes/logout.js
+++ b/routes/logout.js
@@ -12,7 +12,9 @@ const logoutController = require('../controllers/logoutController');
 // ── GET /logout/ ───────────────────────────────────────────────────────────
 // Every other service redirects to http://localhost:4500/logout?token=...
 // Express matches this to GET /logout/ via the mount prefix.
-router.get('/', auth, logoutController.logoutPage);
+// We DO NOT use the auth middleware here because we want the page to always load
+// so that our client-side history trap and session checks can execute.
+router.get('/', logoutController.logoutPage);
 
 // ── POST /logout/begin-logout ──────────────────────────────────────────────
 // Called when the user clicks "Proceed to logout".

--- a/views/logout.ejs
+++ b/views/logout.ejs
@@ -47,6 +47,85 @@
     <!-- Toast container — used by script.js showToast() -->
     <div id="toast-container"></div>
 
+    <script>
+        /**
+         * ── Aggressive History Trap & Logout Guard ──────────────────────────────
+         * This script ensures that once a user is on the logout page, they
+         * cannot navigate away via the back button. If they return here
+         * after being logged out, they are instantly redirected.
+         */
+        (function() {
+            // Inline showToast for immediate use
+            window.showToast = function(message, type, duration) {
+                type = type || 'info';
+                duration = duration || 5000;
+                var container = document.getElementById('toast-container');
+                if (!container) return;
+                var toast = document.createElement('div');
+                toast.className = 'toast ' + type;
+                toast.textContent = message;
+                container.appendChild(toast);
+                requestAnimationFrame(function() {
+                    requestAnimationFrame(function() { toast.classList.add('show'); });
+                });
+                setTimeout(function() {
+                    toast.classList.remove('show');
+                    setTimeout(function() {
+                        if (container.contains(toast)) container.removeChild(toast);
+                    }, 350);
+                }, duration);
+            };
+
+            function trapHistory() {
+                // Push a new entry so that a 'back' click merely triggers 'popstate'
+                // rather than actually navigating away to a previous page.
+                history.pushState(null, "", window.location.href);
+            }
+
+            function checkSessionAndTrap() {
+                var urlParams = new URLSearchParams(window.location.search);
+                var urlToken = urlParams.get('token');
+
+                // If a token is in the URL, store it and clean the URL immediately
+                if (urlToken) {
+                    localStorage.setItem('token', urlToken);
+                    history.replaceState(null, '', window.location.pathname);
+                }
+
+                var token = localStorage.getItem('token');
+
+                // If no token exists (user logged out), show toast and redirect
+                if (!token) {
+                    window.showToast('Kindly log in again to access the app', 'info', 3000);
+
+                    // Maintain the trap entry even while we wait for the redirect
+                    trapHistory();
+
+                    setTimeout(function() {
+                        window.location.replace('http://localhost:3000');
+                    }, 2000);
+                    return;
+                }
+
+                // If session is active, keep trapping to prevent back-navigation to previous app pages
+                trapHistory();
+            }
+
+            // Handle back-button / forward-button
+            window.addEventListener('popstate', function() {
+                checkSessionAndTrap();
+            });
+
+            // Handle page loads from cache
+            window.addEventListener('pageshow', function() {
+                checkSessionAndTrap();
+            });
+
+            // Initial execution
+            checkSessionAndTrap();
+        })();
+    </script>
+
     <header>
         <h1>Logout Page - PDF Labs</h1>
         <p>So sad to see you go!</p>


### PR DESCRIPTION
The logout-service now effectively prevents users from navigating back to the logout page or previous authenticated pages using the browser's back button. This is achieved through a multi-layered approach:
1. **Server-side:** The `/logout` route is now public to ensure the page always loads, allowing client-side logic to run even after the session is destroyed.
2. **Client-side (Immediate):** An inline script in `logout.ejs` executes as soon as the page loads. It strips the JWT token from the URL (to prevent re-auth on refresh) and stores it in `localStorage`.
3. **History Trap:** The script uses `history.pushState` and listeners for `popstate` and `pageshow` to intercept back-navigation attempts. If a user attempts to go back, they are instead redirected to the account service (`http://localhost:3000/?loggedOut=true`) with an informative toast notification.
4. **Token Management:** `public/js/script.js` has been updated to remove redundant token handling and ensure consistent redirects.

These changes provide a professional and secure user experience that respects modern browser constraints while strictly enforcing logout boundaries.

---
*PR created automatically by Jules for task [10167184069707352120](https://jules.google.com/task/10167184069707352120) started by @Godfrey22152*